### PR TITLE
bump knp gaufrette bundle version for symfony 3.4 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require": {
         "oneup/uploader-bundle": "~1.3",
-        "knplabs/knp-gaufrette-bundle": "~0.3.0",
+        "knplabs/knp-gaufrette-bundle": "~0.5.0",
         "liip/imagine-bundle": "~1.7.1",
         "symfony/symfony": "~3.0"
     },


### PR DESCRIPTION
clear deprecation notices with gaufrette bundle bump.